### PR TITLE
feat(new-template): add `s3-shared-bucket-artifacts` example, reusing a single bucket for multiple projects

### DIFF
--- a/s3-shared-bucket-artifacts/README.md
+++ b/s3-shared-bucket-artifacts/README.md
@@ -1,0 +1,38 @@
+# Serverless Framework with shared S3 Artifacts bucket
+
+**Note:** In this example, we are using Serverless Framework Pro features. Please, adapt and modify for your use case if you do not use this service.
+
+The current folder structure in this repository is:
+
+```bash
+resources/
+  s3/
+    serverless.yml
+services/
+  serviceA/
+    serverless.yml
+  serviceB/
+    serverless.yml
+  serviceC/
+    serverless.yml
+.gitignore
+README.md
+```
+
+When using Serverless Framework, the default behaviour is to create a S3 bucket for each `serverless.yml` file, since they are treated as separated project.
+
+[You can easily hit the soft limit of 100 S3 buckets in AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html) and depending on your workload, you can even hit the 1,000 limit.
+
+In this template, you can find a `/resources/s3/serverless.yml`, where we define a S3 as our artifact target that will be used by `/services/service{A,B,C}`.
+
+**We are reusing a single bucket for multiple projects**, helping reduce the burden of creating multiple S3 buckets for Serverless Framework applications in your account.
+
+## Expected Outcome
+
+![](https://dev-to-uploads.s3.amazonaws.com/i/zt1h3tzoejycdq54wgj6.png)
+
+![](https://dev-to-uploads.s3.amazonaws.com/i/1f7kdwqlns6aky4rj8wa.png)
+
+![](https://dev-to-uploads.s3.amazonaws.com/i/ndm40l9jwgzf382c68ap.png)
+
+![](https://dev-to-uploads.s3.amazonaws.com/i/t0kw1suuvsdv6nck9b24.png)

--- a/s3-shared-bucket-artifacts/resources/s3/serverless.yml
+++ b/s3-shared-bucket-artifacts/resources/s3/serverless.yml
@@ -1,0 +1,27 @@
+org: serverlessguru
+app: patterns
+service: ${self:app}-shared-bucket-artifacts
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: ${opt:stage, "dev"}
+  region: ${opt:region, "us-west-2"}
+  profile: ${opt:profile, "default"}
+
+custom:
+  basename: ${self:service}-${self:provider.stage}
+  bucketname: ${self:custom.basename}-${self:provider.region}-artifacts
+
+resources:
+  Resources:
+    S3SharedBucketArtifacts:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:custom.bucketname}
+
+outputs:
+  S3SharedBucketArtifactsName:
+    Ref: S3SharedBucketArtifacts
+  S3SharedBucketArtifactsArn:
+    Fn::GetAtt: S3SharedBucketArtifacts.Arn

--- a/s3-shared-bucket-artifacts/services/serviceA/index.js
+++ b/s3-shared-bucket-artifacts/services/serviceA/index.js
@@ -1,0 +1,6 @@
+module.exports.handler = async event => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ message: "hello world" })
+  };
+};

--- a/s3-shared-bucket-artifacts/services/serviceA/serverless.yml
+++ b/s3-shared-bucket-artifacts/services/serviceA/serverless.yml
@@ -1,0 +1,33 @@
+org: serverlessguru
+app: patterns
+service: ${self:app}-serviceA
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: ${opt:stage, "dev"}
+  region: ${opt:region, "us-west-2"}
+  profile: ${opt:profile, "default"}
+  deploymentBucket:
+    name: ${self:custom.sharedBucketName}
+
+custom:
+  basename: ${self:service}-${self:provider.stage}
+  sharedBucketName: ${output:${self:app}-shared-bucket-artifacts.S3SharedBucketArtifactsName}
+
+package:
+  exclude:
+    - ./**
+  include:
+    - index.js
+
+functions:
+  test:
+    name: ${self:custom.basename}-test
+    handler: index.handler
+    description: Returns "Hello World". Dummy function for API deployment
+    events:
+      - http:
+          path: /test
+          method: any
+          cors: true

--- a/s3-shared-bucket-artifacts/services/serviceB/index.js
+++ b/s3-shared-bucket-artifacts/services/serviceB/index.js
@@ -1,0 +1,6 @@
+module.exports.handler = async event => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ message: "hello world" })
+  };
+};

--- a/s3-shared-bucket-artifacts/services/serviceB/serverless.yml
+++ b/s3-shared-bucket-artifacts/services/serviceB/serverless.yml
@@ -1,0 +1,33 @@
+org: serverlessguru
+app: patterns
+service: ${self:app}-serviceB
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: ${opt:stage, "dev"}
+  region: ${opt:region, "us-west-2"}
+  profile: ${opt:profile, "default"}
+  deploymentBucket:
+    name: ${self:custom.sharedBucketName}
+
+custom:
+  basename: ${self:service}-${self:provider.stage}
+  sharedBucketName: ${output:${self:app}-shared-bucket-artifacts.S3SharedBucketArtifactsName}
+
+package:
+  exclude:
+    - ./**
+  include:
+    - index.js
+
+functions:
+  test:
+    name: ${self:custom.basename}-test
+    handler: index.handler
+    description: Returns "Hello World". Dummy function for API deployment
+    events:
+      - http:
+          path: /test
+          method: any
+          cors: true

--- a/s3-shared-bucket-artifacts/services/serviceC/index.js
+++ b/s3-shared-bucket-artifacts/services/serviceC/index.js
@@ -1,0 +1,6 @@
+module.exports.handler = async event => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ message: "hello world" })
+  };
+};

--- a/s3-shared-bucket-artifacts/services/serviceC/serverless.yml
+++ b/s3-shared-bucket-artifacts/services/serviceC/serverless.yml
@@ -1,0 +1,33 @@
+org: serverlessguru
+app: patterns
+service: ${self:app}-serviceC
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: ${opt:stage, "dev"}
+  region: ${opt:region, "us-west-2"}
+  profile: ${opt:profile, "default"}
+  deploymentBucket:
+    name: ${self:custom.sharedBucketName}
+
+custom:
+  basename: ${self:service}-${self:provider.stage}
+  sharedBucketName: ${output:${self:app}-shared-bucket-artifacts.S3SharedBucketArtifactsName}
+
+package:
+  exclude:
+    - ./**
+  include:
+    - index.js
+
+functions:
+  test:
+    name: ${self:custom.basename}-test
+    handler: index.handler
+    description: Returns "Hello World". Dummy function for API deployment
+    events:
+      - http:
+          path: /test
+          method: any
+          cors: true


### PR DESCRIPTION
### Serverless Framework with shared S3 Artifacts bucket

**Note:** In this example, we are using Serverless Framework Pro features. Please, adapt and modify for your use case if you do not use this service.

The current folder structure in this repository is:

```bash
resources/
  s3/
    serverless.yml
services/
  serviceA/
    serverless.yml
  serviceB/
    serverless.yml
  serviceC/
    serverless.yml
.gitignore
README.md
```

When using Serverless Framework, the default behaviour is to create a S3 bucket for each `serverless.yml` file, since they are treated as separated project.

[You can easily hit the soft limit of 100 S3 buckets in AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html) and depending on your workload, you can even hit the 1,000 limit.

In this template, you can find a `/resources/s3/serverless.yml`, where we define a S3 as our artifact target that will be used by `/services/service{A,B,C}`.

**We are reusing a single bucket for multiple projects**, helping reduce the burden of creating multiple S3 buckets for Serverless Framework applications in your account.

## Expected Outcome

![](https://dev-to-uploads.s3.amazonaws.com/i/zt1h3tzoejycdq54wgj6.png)

![](https://dev-to-uploads.s3.amazonaws.com/i/1f7kdwqlns6aky4rj8wa.png)

![](https://dev-to-uploads.s3.amazonaws.com/i/ndm40l9jwgzf382c68ap.png)

![](https://dev-to-uploads.s3.amazonaws.com/i/t0kw1suuvsdv6nck9b24.png)
