### PR TITLE
AWS Env Variables

### DIFF
--- a/cicd/scripts/deploy.bash
+++ b/cicd/scripts/deploy.bash
@@ -48,7 +48,8 @@ then
     CICD_USER_AWS_SECRET_ACCESS_KEY=$PROD_CICD_USER_AWS_SECRET_ACCESS_KEY
 fi
 
-sls config credentials --provider aws --key $CICD_USER_AWS_ACCESS_KEY --secret $CICD_USER_AWS_SECRET_ACCESS_KEY -o
+export AWS_ACCESS_KEY_ID=$CICD_USER_AWS_ACCESS_KEY
+export AWS_SECRET_ACCESS_KEY=$CICD_USER_AWS_SECRET_ACCESS_KEY
 
 assume_call=$(aws sts assume-role --role-arn $CICD_ROLE_ARN --role-session-name AWSCLI-Session)
 

--- a/cicd/scripts/remove.bash
+++ b/cicd/scripts/remove.bash
@@ -48,7 +48,8 @@ then
     CICD_USER_AWS_SECRET_ACCESS_KEY=$PROD_CICD_USER_AWS_SECRET_ACCESS_KEY
 fi
 
-sls config credentials --provider aws --key $CICD_USER_AWS_ACCESS_KEY --secret $CICD_USER_AWS_SECRET_ACCESS_KEY -o
+export AWS_ACCESS_KEY_ID=$CICD_USER_AWS_ACCESS_KEY
+export AWS_SECRET_ACCESS_KEY=$CICD_USER_AWS_SECRET_ACCESS_KEY
 
 assume_call=$(aws sts assume-role --role-arn $CICD_ROLE_ARN --role-session-name AWSCLI-Session)
 


### PR DESCRIPTION
Stop creating/overriding the default AWS profile in favor of using shell env variables.

When using the deploy/remove scripts locally, it overrides the default AWS profile you had set and it might not be the intended behavior.