### PR TITLE
[sls-eventbridge] chore: event triggers to EventBridge; AWS preferred way

### DIFF
--- a/sls-eventbridge/serverless.yml
+++ b/sls-eventbridge/serverless.yml
@@ -11,13 +11,14 @@ functions:
   scheduledService:
     handler: handler.scheduledService
     events:
-      - schedule: rate(1 minute)
+      - eventBridge:
+          schedule: rate(1 minute)
 
   invoiceService:
     handler: handler.invoiceService
     events:
-      - cloudwatchEvent:
-          event:            
+      - eventBridge:
+          pattern:
             detail:
               operation:
                 - invoice-service
@@ -25,8 +26,8 @@ functions:
   rewardService:
     handler: handler.rewardService
     events:
-      - cloudwatchEvent:
-          event:            
+      - eventBridge:
+          pattern:
             detail:
               operation:
                 - reward-service


### PR DESCRIPTION
As event triggers, AWS favours using EventBridge over CloudWatch Events. 

See https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html
> Amazon EventBridge is the preferred way to manage your events. CloudWatch Events and EventBridge are the same underlying service and API, but EventBridge provides more features.

and https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html
> New features added to EventBridge are not added to CloudWatch Events.
