### PR TITLE
Lambda vpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,9 @@ backup/
 obj/
 bin/
 
+**/node_modules
+**/.serverless
+**/.idea
+
 # Allow
 !cdk-lambda-deployment/bin


### PR DESCRIPTION
lambda-vpc working code has been implemented in this branch.

This code will help to understand why lambda that is inside a private vpc is not able to access S3. Note that private vpc doesn't have access to the internet. Then it shows a solution of creating vpcendpoint of gateway type will solve the purpose.