### PR TITLE
Protect AWS API Gateway from DDoS with AWS WAF via Serverless Framework

### DIFF
--- a/sls-waf-apigateway/.gitignore
+++ b/sls-waf-apigateway/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/sls-waf-apigateway/README.md
+++ b/sls-waf-apigateway/README.md
@@ -1,0 +1,29 @@
+### Protect AWS API Gateway from DDoS with AWS WAF via Serverless Framework
+
+In this template, we demonstrate below AWS services:
+- Amazon API Gateway
+- AWS Lambda
+- AWS WAF
+
+Use Cases Covered:
+- Prevent HTTP Flood DDos Attack on API Gateway Using AWS WAF Web ACL Rate-Based Rule
+
+### Deploy
+`serverless deploy`
+
+### This Serverless Framework Template IaC will Create
+- 1 REST API in API Gateway along with Lambda Function
+- 1 AWS WAF Regional Web ACL with Rate-Based Rule to Prevent HTTP Flood DDos Attack
+- Associate WAF Web ACL with API Gateway of current stack
+
+#### This POC Demo API call use cases details (Test your WAF Web ACL Enabled Secure APIs)
+1. Do a normal call to your API Gateway APIs endpoint and it should give response data
+**WAF Allows: ** `{
+    "message": "WAF protected API Call Response!"
+}
+`
+
+2. Use [Artillery](https://www.artillery.io/) tool to send a large number of requests in a short period to trigger your rate limit rule: `$artillery quick -n 2000 --count 10 https://XXXXXXXXXX.execute-api.us-east-1.amazonaws.com/dev/todo/list
+`
+Using this command, Artillery sends 2000 requests to your API from 10 concurrent users. By doing this, you trigger the rate limit rule in less than the 5-minute threshold. Once Artillery finishes its execution, re-running the API and API response will be:
+**WAF Blocked:** `{"message":"Forbidden"}`

--- a/sls-waf-apigateway/handler.js
+++ b/sls-waf-apigateway/handler.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports.todolist = async (event) => {
+  return {
+    statusCode: 200,
+    body: JSON.stringify(
+      {
+        message: 'WAF protected API Call Response!'
+      },
+      null,
+      2
+    ),
+  };
+};

--- a/sls-waf-apigateway/package-lock.json
+++ b/sls-waf-apigateway/package-lock.json
@@ -1,0 +1,73 @@
+{
+  "name": "sls-waf-apigateway",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "serverless-associate-waf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/serverless-associate-waf/-/serverless-associate-waf-1.2.1.tgz",
+      "integrity": "sha512-84FIjRsNJ4im+Q1rmlwc+7ofyZXB6D0AZr9tfbBCfh25/qwv/8Q9h78/aDrR7LZT5XAZzrM6qAbwHFyUD5wd+A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    }
+  }
+}

--- a/sls-waf-apigateway/package.json
+++ b/sls-waf-apigateway/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sls-waf-apigateway",
+  "version": "1.0.0",
+  "description": "Serverless Framework AWS WAF API Gateway Template",
+  "main": "handler.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Serverless Guru",
+  "license": "ISC",
+  "devDependencies": {
+    "serverless-associate-waf": "^1.2.1"
+  }
+}

--- a/sls-waf-apigateway/resources/waf.yml
+++ b/sls-waf-apigateway/resources/waf.yml
@@ -1,0 +1,27 @@
+# CloudFormation Resources
+# Create WAF Regional Web ACL with Rate-Based Rule to Prevent HTTP Flood DDos Attack
+WAFRegionalWebACL:
+  Type: "AWS::WAFv2::WebACL"
+  Properties:
+    Name: ApiGateway-HTTP-Flood-Prevent-Auto-${self:provider.stage}
+    Scope: REGIONAL
+    Description: WAF Regional Web ACL to Prevent HTTP Flood DDos Attack
+    DefaultAction:
+      Allow: {}
+    VisibilityConfig:
+      SampledRequestsEnabled: true
+      CloudWatchMetricsEnabled: true
+      MetricName: ApiGateway-HTTP-Flood-Prevent-Metric
+    Rules:
+      - Name: HTTP-Flood-Prevent-Rule
+        Priority: 0
+        Action:
+          Block: {}
+        VisibilityConfig:
+          SampledRequestsEnabled: true
+          CloudWatchMetricsEnabled: true
+          MetricName: HTTP-Flood-Prevent-Rule-Metric
+        Statement:
+          RateBasedStatement:
+            AggregateKeyType: IP
+            Limit: 2000  # rate limit adjust as per your real traffic

--- a/sls-waf-apigateway/serverless.yml
+++ b/sls-waf-apigateway/serverless.yml
@@ -1,0 +1,31 @@
+service: sls-waf-apigateway
+frameworkVersion: '3'
+
+provider:
+  name: aws
+  runtime: nodejs14.x
+  region: ${opt:region, "us-east-1"}
+  stage: ${opt:stage, "dev"}
+
+plugins:
+  - serverless-associate-waf
+
+# Associate WAF Web ACL with API Gateway of current stack
+custom:
+  associateWaf:
+    name: ${self:resources.Resources.WAFRegionalWebACL.Properties.Name}
+    version: V2 #(optional) Regional | V2
+
+functions:
+  todolist:
+    handler: handler.todolist
+    events:
+      - http:
+          path: /todo/list
+          method: get
+
+# CloudFormation Resources
+# Create WAF Regional Web ACL with RateBased Rule to Prevent HTTP Flood DDos Attack
+resources:
+  Resources:
+    WAFRegionalWebACL: ${file(resources/waf.yml):WAFRegionalWebACL}


### PR DESCRIPTION
Protect AWS API Gateway from DDoS with AWS WAF via Serverless Framework

Use Cases Covered:
- Prevent HTTP Flood DDos Attack on API Gateway Using AWS WAF Web ACL Rate-Based Rule